### PR TITLE
[DDO-1825] Version-control the Thanos data source

### DIFF
--- a/datasources/dsp-thanos.yaml
+++ b/datasources/dsp-thanos.yaml
@@ -13,6 +13,7 @@ datasources:
     orgId: 1
     # Specifying uid here keeps it consistent across edits
     uid: 8ZLL-_cnk
+    url: http://thanos-local-query.thanos.svc.cluster.local:9090
     isDefault: true
     jsonData:
       httpMethod: POST

--- a/datasources/dsp-thanos.yaml
+++ b/datasources/dsp-thanos.yaml
@@ -1,0 +1,20 @@
+# Increment me each time you edit!
+apiVersion: 1
+
+deleteDatasources:
+  - name: dsp-thanos
+    orgId: 1
+
+datasources:
+  - name: dsp-thanos
+    type: prometheus
+    typeName: Prometheus
+    access: proxy
+    orgId: 1
+    # Specifying uid here keeps it consistent across edits
+    uid: 8ZLL-_cnk
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+    # Prevent UI edits
+    editable: false


### PR DESCRIPTION
Based on my experiences with the Google Cloud Monitoring source, this should just work: when the config file is loaded it'll in one step delete the existing one and overwrite it with this new one