### PR TITLE
[PF-1761] Bump bumper GHA to 0.0.6

### DIFF
--- a/.github/workflows/syncK8s.yaml
+++ b/.github/workflows/syncK8s.yaml
@@ -77,7 +77,7 @@ jobs:
       #
 
       - name: Bump repo tag
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         env:
           DEFAULT_BUMP: patch
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
Bumber is broken with this error “fatal: unsafe repository ('/github/workspace' is owned by someone else)“

It is related with https://github.com/actions/checkout/issues/760

bumber 0.0.6 fix the issue.